### PR TITLE
fix: remove gRPC deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,6 @@ dependencies = [
     "ansys-platform-instancemanagement>=1.0.1",
     "ansys-pythonnet>=3.1.0rc1",
     "ansys-tools-path>=0.3.1",
-    "grpcio>=1.17.0",
-    "protobuf>=3.19.6,<3.21.0",
     "tqdm>=4.65.0",
     "WMI>=1.4.9",
 ]


### PR DESCRIPTION
This pull-requests removes the gRPC dependencies in this package. Instead, these deps are installed via [ansys-api-workbench](https://github.com/ansys-internal/ansys-api-workbench/blob/main/setup.py).