### PR TITLE
fix: link to examples

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -6,7 +6,7 @@ This page collects various examples on how to use PyWorkbench.
 .. grid:: 1
 
    .. grid-item-card:: Official PyWorkbench examples
-      :link: examples.workbench.docs.pyansys.com
+      :link: https://examples.workbench.docs.pyansys.com
       :text-align: center
       :margin: 2 2 0 0
 


### PR DESCRIPTION
Ensures that the examples section of the docs point to the right URL.