### PR TITLE
ci: update dependabot message prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     assignees:
       - "pyansys-ci-bot"
     commit-message:
-      prefix: "MAINT"
+      prefix: "chore"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -21,4 +21,4 @@ updates:
     assignees:
       - "pyansys-ci-bot"
     commit-message:
-      prefix: "MAINT"
+      prefix: "chore"


### PR DESCRIPTION
Change the `MAINT` prefix by `chore` to follow conventional commits.