### PR TITLE
fix: make `WMI` windows only dependency

### DIFF
--- a/doc/changelog.d/105.fixed.md
+++ b/doc/changelog.d/105.fixed.md
@@ -1,0 +1,1 @@
+fix: make `WMI` windows only dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "ansys-pythonnet>=3.1.0rc1",
     "ansys-tools-path>=0.3.1",
     "tqdm>=4.65.0",
-    "WMI>=1.4.9",
+    "WMI>=1.4.9; platform_system=='Windows'",
 ]
 [project.optional-dependencies]
 doc = [


### PR DESCRIPTION
For Ansys Notebook this package doesn't resolve because it can't find pywin32 that satisfies a linux env. This stems from WMI being a dependency that requires pywin32 on all platforms. This PR makes WMI a windows only requirement.

Fixes issue [#100](https://github.com/ansys/pyworkbench/issues/100)