### PR TITLE
fix: use title case in CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,10 +1,10 @@
 # Contributors
 
-## Project lead
+## Project Lead
 
 * [Frank Li](https://github.com/franknli)
 
-## Individual contributors
+## Individual Contributors
 
 * [Jorge Martinez](https://github.com/jorgepiloto)
 * [Revathy Venugopal](https://github.com/Revathyvenugopal162)

--- a/doc/changelog.d/161.fixed.md
+++ b/doc/changelog.d/161.fixed.md
@@ -1,0 +1,1 @@
+fix: use title case in CONTRIBUTORS.md


### PR DESCRIPTION
Fix #132 by sticking to the format proposed in [here](https://raw.githubusercontent.com/ansys-internal/pyansys-maintenance-automation/refs/heads/main/scripts/file_references/CONTRIBUTORS.md?token=GHSAT0AAAAAACHJEVCZVMG4OAWTTQLHMQYWZ2NR3YA).